### PR TITLE
Add parsing of add_appointment command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/appointmentcommands/AddAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/appointmentcommands/AddAppointmentCommand.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_TO;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
-
 import seedu.address.model.Model;
 import seedu.address.model.appointment.Appointment;
 

--- a/src/main/java/seedu/address/logic/commands/appointmentcommands/DeleteAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/appointmentcommands/DeleteAppointmentCommand.java
@@ -28,12 +28,20 @@ public class DeleteAppointmentCommand extends Command {
     private final Index targetIndex;
     private final Appointment toDelete;
 
+    /**
+     * Create {@code DeleteAppointmentCommand} with target index to delete.
+     * @param targetIndex Target index of appointment to delete.
+     */
     public DeleteAppointmentCommand(Index targetIndex) {
         requireNonNull(targetIndex);
         this.targetIndex = targetIndex;
         this.toDelete = null;
     }
 
+    /**
+     * Create {@code DeleteAppointmentCommand} with {@code Appointment} to delete.
+     * @param toDelete Appointment to delete.
+     */
     public DeleteAppointmentCommand(Appointment toDelete) {
         requireNonNull(toDelete);
         this.targetIndex = null;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -281,9 +281,9 @@ public class ParserUtil {
      */
     public static AppointmentDateTime parseDateTime(String dateTime) throws ParseException {
         requireNonNull(dateTime);
-        String trimmedDateTime = dateTime.trim();
+        String trimmedDateTime = dateTime.trim().toUpperCase();
         if (!AppointmentDateTime.isValidDateTime(trimmedDateTime)) {
-            throw new ParseException(Email.MESSAGE_CONSTRAINTS);
+            throw new ParseException(AppointmentDateTime.MESSAGE_CONSTRAINTS);
         }
         return new AppointmentDateTime(trimmedDateTime);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,10 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -13,6 +17,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.subject.SubjectName;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -120,5 +125,46 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String subjectName} into an {@code SubjectName}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code subjectName} is invalid.
+     */
+    public static SubjectName parseSubjectName(String subjectName) throws ParseException {
+        requireNonNull(subjectName);
+        String trimmedSubjectName = subjectName.trim();
+        if (!SubjectName.isValidName(trimmedSubjectName)) {
+            throw new ParseException(SubjectName.MESSAGE_CONSTRAINTS);
+        }
+        return new SubjectName(trimmedSubjectName);
+    }
+
+    /**
+     * Parses a {@code String dateTime} into an {@code DateTime}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code dateTime} is invalid.
+     */
+    public static LocalDateTime parseDateTime(String dateTime) throws ParseException {
+        requireNonNull(dateTime);
+        String trimmedDateTime = dateTime.trim();
+
+        // TODO: Temporary stub before merging AppointmentDateTime
+        DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+                .appendPattern("yyyy-MM-dd HH:mma")
+                .toFormatter();
+        
+        LocalDateTime localDateTime;
+
+        try {
+            localDateTime = LocalDateTime.parse(trimmedDateTime, formatter);
+        } catch (DateTimeParseException e) {
+            throw new ParseException("TODO REPLACE ERROR");
+        }
+
+        return localDateTime;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -156,7 +156,7 @@ public class ParserUtil {
         DateTimeFormatter formatter = new DateTimeFormatterBuilder()
                 .appendPattern("yyyy-MM-dd HH:mma")
                 .toFormatter();
-        
+
         LocalDateTime localDateTime;
 
         try {

--- a/src/main/java/seedu/address/logic/parser/appointmentparser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/appointmentparser/AddAppointmentCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_FROM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_TO;
 
-import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.appointmentcommands.AddAppointmentCommand;
@@ -19,6 +18,7 @@ import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.AppointmentDateTime;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.subject.SubjectName;
@@ -53,7 +53,7 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
         String timeFromString = argMultimap.getValue(PREFIX_TIME_FROM).get();
         String timeToString = argMultimap.getValue(PREFIX_TIME_TO).get();
         String dateTimeString = dateString + " " + timeFromString;
-        LocalDateTime dateTime = ParserUtil.parseDateTime(dateTimeString);
+        AppointmentDateTime dateTime = ParserUtil.parseDateTime(dateTimeString);
 
         Address location = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_LOCATION).get());
 

--- a/src/main/java/seedu/address/logic/parser/appointmentparser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/appointmentparser/AddAppointmentCommandParser.java
@@ -41,7 +41,8 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
         if (!arePrefixesPresent(argMultimap, PREFIX_EMAIL, PREFIX_SUBJECT_NAME, PREFIX_DATE,
                 PREFIX_TIME_FROM, PREFIX_TIME_TO, PREFIX_LOCATION)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAppointmentCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, AddAppointmentCommand.MESSAGE_USAGE));
         }
 
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());

--- a/src/main/java/seedu/address/logic/parser/appointmentparser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/appointmentparser/AddAppointmentCommandParser.java
@@ -8,15 +8,20 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SUBJECT_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_FROM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME_TO;
 
+import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.appointmentcommands.AddAppointmentCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.subject.SubjectName;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -34,13 +39,26 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
                         PREFIX_TIME_TO, PREFIX_LOCATION);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_EMAIL, PREFIX_SUBJECT_NAME, PREFIX_DATE,
-                PREFIX_TIME_FROM, PREFIX_TIME_TO)
+                PREFIX_TIME_FROM, PREFIX_TIME_TO, PREFIX_LOCATION)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAppointmentCommand.MESSAGE_USAGE));
         }
 
-        /* To be implemented */
-        return null;
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        SubjectName subjectName = ParserUtil.parseSubjectName(argMultimap.getValue(PREFIX_SUBJECT_NAME).get());
+
+        // TODO: Handle timeTo
+        String dateString = argMultimap.getValue(PREFIX_DATE).get();
+        String timeFromString = argMultimap.getValue(PREFIX_TIME_FROM).get();
+        String timeToString = argMultimap.getValue(PREFIX_TIME_TO).get();
+        String dateTimeString = dateString + " " + timeFromString;
+        LocalDateTime dateTime = ParserUtil.parseDateTime(dateTimeString);
+
+        Address location = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_LOCATION).get());
+
+        Appointment appointment = new Appointment(email, subjectName, dateTime, location);
+
+        return new AddAppointmentCommand(appointment);
     }
 
     /**

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -1,11 +1,6 @@
 package seedu.address.model.appointment;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
@@ -20,8 +15,6 @@ public class Appointment {
     private final SubjectName subject;
     private final AppointmentDateTime dateTime;
     private final Address location;
-
-    private final String formatter = "dd MM yyyy";
 
     /**
      * Primary constructor for appointment class.
@@ -55,30 +48,9 @@ public class Appointment {
         return location;
     }
 
-    /**
-     * Helper method to parse date time.
-     *
-     * @param date Date in string
-     * @param time 24 hr time in integer
-     * @return LocalDateTime for given date and time
-     */
-    private LocalDateTime parseDateTime(String date, int time) {
-        String[] tempArray = date.split("\\s+");
-        List<Integer> dateList =
-                Arrays.stream(tempArray).map(Integer::parseInt).collect(Collectors.toList());
-        int hour = time / 100;
-        int min = time % 100;
-
-        LocalDateTime dateAndTime = LocalDateTime.of(dateList.get(1), dateList.get(2),
-                dateList.get(3), hour, min);
-        return dateAndTime;
-    }
-
     @Override
     public String toString() {
-        return String.format("Appointment with Tutor (%s) at %s", this.email.value,
-                LocalDateTime.parse(this.dateTime.toString(),
-                        DateTimeFormatter.ofPattern(formatter)));
+        return String.format("Appointment with Tutor (%s) at %s", this.email.value, dateTime.toString());
     }
 
     /**

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -28,7 +28,7 @@ public class Appointment {
      *
      * @param email    Email of tutor.
      * @param subject  Subject tutor is teaching to tutee.
-     * @param dateTime LocalDateTime
+     * @param dateTime Date and time of appointment
      * @param location Location of teaching venue
      */
     public Appointment(Email email, SubjectName subject, AppointmentDateTime dateTime,

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -31,7 +31,7 @@ public class Appointment {
      * @param dateTime LocalDateTime
      * @param location Location of teaching venue
      */
-    Appointment(Email email, SubjectName subject, LocalDateTime dateTime,
+    public Appointment(Email email, SubjectName subject, LocalDateTime dateTime,
                 Address location) {
         this.email = email;
         this.subject = subject;

--- a/src/main/java/seedu/address/model/appointment/AppointmentDateTime.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentDateTime.java
@@ -10,26 +10,22 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 
 /**
- * Represents an Appointment's datetime in the AppointmentList.
+ * Represents an Appointment's date and time in the AppointmentList.
  * Guarantees: immutable; is valid as declared in {@link #isValidDateTime(String)}
  */
 public class AppointmentDateTime {
 
-    public static final String MESSAGE_CONSTRAINTS = "AppointmentDateTime can take any values, "
-            + "and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "AppointmentDateTime should be in "
+            + "YYYY-MM-DD HH:MM AM/PM format";
 
     /*
      * DateTime make use of formatter to validate instead of Regex for DateTime accuracy.
      */
     public static final DateTimeFormatter VALIDATION_PATTERN = new DateTimeFormatterBuilder()
-            .appendPattern("[yyyy-MM-dd HH:mm]")
-            .appendPattern("[yyyy-MM-dd]")
-            .appendPattern("[d-M-yyyy HH:mm]")
-            .appendPattern("[d-M-yyyy]")
-            .appendPattern("[yyyy/MM/dd HH:mm]")
-            .appendPattern("[yyyy/MM/dd]")
-            .appendPattern("[d/M/yyyy HH:mm]")
-            .appendPattern("[d/M/yyyy]")
+            .appendPattern("[y-M-d [H:m[ ][a]]]")
+            .appendPattern("[d-M-y [H:m[ ][a]]]")
+            .appendPattern("[y/M/d [H:m[ ][a]]]")
+            .appendPattern("[d/M/y [H:m[ ][a]]]")
             .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
             .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
             .toFormatter();
@@ -43,6 +39,7 @@ public class AppointmentDateTime {
      */
     public AppointmentDateTime(String dateTime) {
         requireNonNull(dateTime);
+        dateTime = dateTime.toUpperCase();
         checkArgument(isValidDateTime(dateTime), MESSAGE_CONSTRAINTS);
         value = LocalDateTime.parse(dateTime, VALIDATION_PATTERN);
     }


### PR DESCRIPTION
Closes #93

While the AddAppointment command was implemented, the parsing was not yet implemented and the `add_appointment` command did not work.

This PR adds parsing for `add_appointment` and fixes some checkstyle errors.

`add_appointment e/johnd@example.com s/Mathematics d/2021-3-1 fr/10:00 am to/12:00 am l/Clementi` works and adds an appointment to the appointment list.

TODO in the future:
- Add parsing of both fromTime and toTime