### PR TITLE
Fix bug where clear error message is not given if not all subject fields are given in edit_tutor

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -97,6 +97,8 @@ This feature allows tutees to maintain and keep track of the list of tuition tut
 
 Add a new tutor and enter their basic details as well as an optional note.
 
+Multiple subjects may be provided, and all subject attributes must be present when providing a subject.
+
 Format:
 `add_tutor n/NAME g/GENDER p/PHONE_NUMBER e/EMAIL  a/ADDRESS <s/SUBJECT_NAME r/SUBJECT_RATE l/SUBJECT_EDUCATION_LEVEL y/SUBJECT_YEARS_EXPERIENCE q/SUBJECT_QUALIFICATIONS>... notes/NOTE`
 
@@ -143,6 +145,10 @@ Example: `delete_tutor 1` deletes the first tutor.
 #### Edit a tutor: `edit_tutor`
 
 Edit a tutor's information by index. Only the attributes present can be changed in the tutor, including notes.
+
+All subjects taught by the tutor will be overwritten by subjects provided to
+this command. Furthermore, all subject attributes must be present when providing
+a subject.
 
 Format: `edit_tutor INDEX [n/NAME] [g/GENDER] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [<s/SUBJECT_NAME r/SUBJECT_RATE l/SUBJECT_EDUCATION_LEVEL y/SUBJECT_YEARS_EXPERIENCE q/SUBJECT_QUALIFICATIONS>]... notes/NOTES`
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -43,7 +43,7 @@ import seedu.address.model.tutor.Phone;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-    public static final String SUBJECT_LIST_INVALID_LENGTH = "Each Tutor Subject must have all fields defined.";
+    public static final String SUBJECT_LIST_INVALID_LENGTH = "All subjects must have all attributes provided.";
     public static final String MESSAGE_INVALID_DATE = "Date should be in YYYY-MM-DD format.";
     public static final String MESSAGE_INVALID_TIME = "Tune should be in HH:MM AM/PM format";
 

--- a/src/main/java/seedu/address/logic/parser/tutorparser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tutorparser/EditCommandParser.java
@@ -17,7 +17,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_YEAR;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -78,21 +77,15 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editTutorDescriptor::setTags);
 
-        List<String> subjectNames = argMultimap.getAllValues(PREFIX_SUBJECT_NAME);
-        List<String> subjectLevels = argMultimap.getAllValues(PREFIX_EDUCATION_LEVEL);
-        List<String> subjectRates = argMultimap.getAllValues(PREFIX_RATE);
-        List<String> subjectExperiences = argMultimap.getAllValues(PREFIX_YEAR);
-        List<String> subjectQualifications = argMultimap.getAllValues(PREFIX_QUALIFICATION);
+        SubjectList subjectList = ParserUtil.parseSubjectList(
+                argMultimap.getAllValues(PREFIX_SUBJECT_NAME),
+                argMultimap.getAllValues(PREFIX_EDUCATION_LEVEL),
+                argMultimap.getAllValues(PREFIX_RATE),
+                argMultimap.getAllValues(PREFIX_YEAR),
+                argMultimap.getAllValues(PREFIX_QUALIFICATION)
+        );
 
-        // TODO: Merge with existing list instead of overwriting
-        if (subjectNames.size() > 0) {
-            SubjectList subjectList = ParserUtil.parseSubjectList(
-                    subjectNames,
-                    subjectLevels,
-                    subjectRates,
-                    subjectExperiences,
-                    subjectQualifications);
-
+        if (subjectList.size() > 0) {
             editTutorDescriptor.setSubjectList(subjectList);
         }
 

--- a/src/main/java/seedu/address/model/subject/SubjectList.java
+++ b/src/main/java/seedu/address/model/subject/SubjectList.java
@@ -87,6 +87,13 @@ public class SubjectList implements Iterable<TutorSubject> {
     }
 
     /**
+     * Returns the number of subjects in this list.
+     */
+    public int size() {
+        return internalList.size();
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<TutorSubject> asUnmodifiableObservableList() {


### PR DESCRIPTION
Checks if all fields are given for all subjects in `edit_tutor` command and provide a clear error message if this constraint is not met.

Updates user guide to clarify this constraint.